### PR TITLE
Add Customer module with CRUD and transfer logic

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,13 @@
 <?php
 
 use Modules\Auth\Controller\AuthController;
+use Modules\Customer\Controller\CustomerController;
 
 $router->add('POST','/api/auth/login',[AuthController::class,'login']);
 $router->add('GET','/api/auth/me',[AuthController::class,'me']);
+
+$router->add('GET',    '/api/customers',               [CustomerController::class,'index']);
+$router->add('GET',    '/api/customers/{id:\d+}',      [CustomerController::class,'show']);
+$router->add('POST',   '/api/customers',               [CustomerController::class,'store']);
+$router->add('PUT',    '/api/customers/{id:\d+}',      [CustomerController::class,'update']);
+$router->add('POST',   '/api/customers/transfer',      [CustomerController::class,'transfer']);

--- a/database/migrations/2025_08_01_create_customer_table.sql
+++ b/database/migrations/2025_08_01_create_customer_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS doctor_info (
+    id           INT AUTO_INCREMENT PRIMARY KEY,
+    doctor_type  ENUM('Male','Female','Clinic','Hospital','Company','infirmary','Pharmacy','Laboratory') NOT NULL,
+    name         VARCHAR(255) NOT NULL,
+    mobile       VARCHAR(20)   NOT NULL UNIQUE,
+    address      TEXT           NULL,
+    specialty    VARCHAR(100)   NULL,
+    national_id  VARCHAR(20)    NULL,
+    created_by   INT            NULL,
+    type_add     TINYINT       NOT NULL DEFAULT 1,
+    created_at   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    INDEX(mobile),
+    FOREIGN KEY (created_by) REFERENCES users(id)
+);

--- a/docs/CustomerModule.md
+++ b/docs/CustomerModule.md
@@ -1,0 +1,38 @@
+# Customer Module
+
+CRUD endpoints for managing doctors (customers).
+
+## Create Customer
+POST `/api/customers`
+```json
+{
+  "doctor_type": "Male",
+  "name": "Dr. Strange",
+  "mobile": "0912000000"
+}
+```
+Response
+```json
+{
+  "success": true,
+  "message": "created",
+  "data": {"id": 1}
+}
+```
+
+## Transfer Ownership
+POST `/api/customers/transfer`
+```json
+{
+  "mobile": "0912000000",
+  "newOwner": 5
+}
+```
+Response
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {"id": 1}
+}
+```

--- a/src/Modules/Customer/Controller/CustomerController.php
+++ b/src/Modules/Customer/Controller/CustomerController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Modules\Customer\Controller;
+
+use Modules\Customer\Service\CustomerService;
+
+class CustomerController
+{
+    public function __construct(private CustomerService $service)
+    {
+    }
+
+    public function index($request)
+    {
+        $query = $request->getQueryParams();
+        $page = (int)($query['page'] ?? 1);
+        $search = $query['search'] ?? '';
+        $data = $this->service->list($page, $search);
+        return ['status' => 200, 'body' => ['success' => true, 'message' => 'ok', 'data' => $data]];
+    }
+
+    public function show($request, $id)
+    {
+        try {
+            $customer = $this->service->get((int)$id);
+            return ['status' => 200, 'body' => ['success' => true, 'message' => 'ok', 'data' => $customer]];
+        } catch (\RuntimeException $e) {
+            return ['status' => 404, 'body' => ['success' => false, 'message' => $e->getMessage(), 'data' => null]];
+        }
+    }
+
+    public function store($request)
+    {
+        $data = $request->getParsedBody();
+        $user = $request->getAttribute('user') ?? [];
+        $id = $this->service->create($data, (int)($user['id'] ?? 0));
+        return ['status' => 201, 'body' => ['success' => true, 'message' => 'created', 'data' => ['id' => $id]]];
+    }
+
+    public function update($request, $id)
+    {
+        $data = $request->getParsedBody();
+        $this->service->update((int)$id, $data);
+        return ['status' => 200, 'body' => ['success' => true, 'message' => 'updated', 'data' => null]];
+    }
+
+    public function transfer($request)
+    {
+        $data = $request->getParsedBody();
+        try {
+            $id = $this->service->transferIfEligible($data['mobile'] ?? '', (int)($data['newOwner'] ?? 0));
+            return ['status' => 200, 'body' => ['success' => true, 'message' => 'ok', 'data' => ['id' => $id]]];
+        } catch (\RuntimeException $e) {
+            return ['status' => 400, 'body' => ['success' => false, 'message' => $e->getMessage(), 'data' => null]];
+        }
+    }
+}

--- a/src/Modules/Customer/Repository/CustomerRepository.php
+++ b/src/Modules/Customer/Repository/CustomerRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Modules\Customer\Repository;
+
+use PDO;
+use DateTime;
+
+class CustomerRepository
+{
+    public function __construct(private PDO $db)
+    {
+    }
+
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM doctor_info WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $data ?: null;
+    }
+
+    public function findByMobile(string $mobile): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM doctor_info WHERE mobile = :mobile');
+        $stmt->execute(['mobile' => $mobile]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $data ?: null;
+    }
+
+    public function create(array $data, int $createdBy): int
+    {
+        $data['created_by'] = $createdBy;
+        $columns = ['doctor_type','name','mobile','address','specialty','national_id','created_by','type_add'];
+        $cols = [];
+        $params = [];
+        foreach ($columns as $col) {
+            if (isset($data[$col])) {
+                $cols[] = $col;
+                $params[":$col"] = $data[$col];
+            }
+        }
+        $sql = 'INSERT INTO doctor_info (' . implode(',', $cols) . ')
+                VALUES (' . implode(',', array_keys($params)) . ')';
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute($params);
+        return (int)$this->db->lastInsertId();
+    }
+
+    public function update(int $id, array $fields): bool
+    {
+        if (!$fields) {
+            return true;
+        }
+        $sets = [];
+        $params = [];
+        foreach ($fields as $k => $v) {
+            $sets[] = "$k = :$k";
+            $params[":$k"] = $v;
+        }
+        $params[':id'] = $id;
+        $sql = 'UPDATE doctor_info SET ' . implode(',', $sets) . ' WHERE id = :id';
+        $stmt = $this->db->prepare($sql);
+        return $stmt->execute($params);
+    }
+
+    public function transfer(int $id, int $newOwner): bool
+    {
+        $stmt = $this->db->prepare('UPDATE doctor_info SET created_by = :owner WHERE id = :id');
+        return $stmt->execute(['owner' => $newOwner, 'id' => $id]);
+    }
+
+    public function getLastPurchaseDate(int $id): ?DateTime
+    {
+        $sql = "SELECT MAX(created_at) AS last FROM invoices_new WHERE doctor_id = :id AND approval_summary IN ('تایید نهایی','ارسال کالا','منتظر تایید حسابداری')";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row || !$row['last']) {
+            return null;
+        }
+        return new DateTime($row['last']);
+    }
+
+    public function list(int $offset, int $limit, string $search = ''): array
+    {
+        $params = ['limit' => $limit, 'offset' => $offset];
+        $sql = 'SELECT * FROM doctor_info';
+        if ($search) {
+            $sql .= ' WHERE name LIKE :search OR mobile LIKE :search';
+            $params['search'] = "%$search%";
+        }
+        $sql .= ' ORDER BY id DESC LIMIT :limit OFFSET :offset';
+        $stmt = $this->db->prepare($sql);
+        foreach ($params as $k => $v) {
+            $type = $k === 'limit' || $k === 'offset' ? PDO::PARAM_INT : PDO::PARAM_STR;
+            $stmt->bindValue($k, $v, $type);
+        }
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/src/Modules/Customer/Service/CustomerService.php
+++ b/src/Modules/Customer/Service/CustomerService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Modules\Customer\Service;
+
+use Modules\Customer\Repository\CustomerRepository;
+use DateTime;
+
+class CustomerService
+{
+    public function __construct(private CustomerRepository $repo)
+    {
+    }
+
+    public function get(int $id): array
+    {
+        $customer = $this->repo->find($id);
+        if (!$customer) {
+            throw new \RuntimeException('Customer not found');
+        }
+        return $customer;
+    }
+
+    public function list(int $page, string $search = ''): array
+    {
+        $limit = 20;
+        $offset = ($page - 1) * $limit;
+        return $this->repo->list($offset, $limit, $search);
+    }
+
+    public function create(array $dto, int $userId): int
+    {
+        return $this->repo->create($dto, $userId);
+    }
+
+    public function update(int $id, array $dto): void
+    {
+        $existing = $this->get($id);
+        $changes = [];
+        foreach ($dto as $k => $v) {
+            if (array_key_exists($k, $existing) && $existing[$k] !== $v) {
+                $changes[$k] = $v;
+            }
+        }
+        $this->repo->update($id, $changes);
+    }
+
+    public function transferIfEligible(string $mobile, int $newOwner): int
+    {
+        $doctor = $this->repo->findByMobile($mobile);
+        if (!$doctor) {
+            return $this->repo->create([
+                'doctor_type' => 'Male',
+                'name' => $mobile,
+                'mobile' => $mobile,
+            ], $newOwner);
+        }
+
+        if (($doctor['created_by'] ?? 0) == $newOwner) {
+            return $doctor['id'];
+        }
+
+        $last = $this->repo->getLastPurchaseDate($doctor['id']);
+        $threshold = new DateTime('-45 days');
+        if (!$last || $last < $threshold) {
+            $this->repo->transfer($doctor['id'], $newOwner);
+            return $doctor['id'];
+        }
+
+        throw new \RuntimeException('Transfer not allowed within 45 days');
+    }
+}

--- a/tests/Customer/CustomerServiceTest.php
+++ b/tests/Customer/CustomerServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Modules\Customer\Service\CustomerService;
+use Modules\Customer\Repository\CustomerRepository;
+use PHPUnit\Framework\TestCase;
+
+class CustomerServiceTest extends TestCase
+{
+    public function testCreateAndRetrieve(): void
+    {
+        $repo = new class extends CustomerRepository {
+            public array $data = [];
+            public function __construct() {}
+            public function create(array $data, int $createdBy): int { $data['id'] = 1; $this->data[1] = $data; return 1; }
+            public function find(int $id): ?array { return $this->data[$id] ?? null; }
+        };
+        $service = new CustomerService($repo);
+        $id = $service->create(['doctor_type' => 'Male', 'name' => 'Doc', 'mobile' => '123'], 9);
+        $this->assertSame(1, $id);
+        $customer = $service->get(1);
+        $this->assertSame('Doc', $customer['name']);
+    }
+
+    public function testUpdateDetectsChanges(): void
+    {
+        $repo = new class extends CustomerRepository {
+            public array $data = [1 => ['id' => 1, 'name' => 'Old', 'mobile' => '123', 'doctor_type' => 'Male']];
+            public array $updated = [];
+            public function __construct() {}
+            public function find(int $id): ?array { return $this->data[$id] ?? null; }
+            public function update(int $id, array $fields): bool { $this->updated = $fields; return true; }
+        };
+        $service = new CustomerService($repo);
+        $service->update(1, ['name' => 'New', 'mobile' => '123']);
+        $this->assertSame(['name' => 'New'], $repo->updated);
+    }
+
+    public function testTransferLogic(): void
+    {
+        // new customer
+        $repoNew = new class extends CustomerRepository {
+            public function __construct() {}
+            public function findByMobile(string $mobile): ?array { return null; }
+            public function create(array $data, int $createdBy): int { return 5; }
+        };
+        $serviceNew = new CustomerService($repoNew);
+        $id = $serviceNew->transferIfEligible('555', 2);
+        $this->assertSame(5, $id);
+
+        // within 45 days should throw
+        $repoRecent = new class extends CustomerRepository {
+            public function __construct() {}
+            public function findByMobile(string $mobile): ?array { return ['id' => 1, 'created_by' => 1]; }
+            public function getLastPurchaseDate(int $id): ?DateTime { return new DateTime('-30 days'); }
+        };
+        $serviceRecent = new CustomerService($repoRecent);
+        $this->expectException(\RuntimeException::class);
+        $serviceRecent->transferIfEligible('555', 2);
+
+        // beyond 45 days transfers
+        $repoOld = new class extends CustomerRepository {
+            public bool $transferred = false;
+            public function __construct() {}
+            public function findByMobile(string $mobile): ?array { return ['id' => 1, 'created_by' => 1]; }
+            public function getLastPurchaseDate(int $id): ?DateTime { return new DateTime('-60 days'); }
+            public function transfer(int $id, int $newOwner): bool { $this->transferred = true; return true; }
+        };
+        $serviceOld = new CustomerService($repoOld);
+        $id = $serviceOld->transferIfEligible('555', 2);
+        $this->assertTrue($repoOld->transferred);
+        $this->assertSame(1, $id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `doctor_info` table migration
- implement customer repository, service, controller and routes
- support ownership transfer after 45 days and document API

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6895fdffa70883279eb00e239129e5d7